### PR TITLE
Trust user-installed CAs in release builds.

### DIFF
--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -8,11 +8,7 @@
     <base-config>
         <trust-anchors>
             <certificates src="system" />
-        </trust-anchors>
-    </base-config>
-    <debug-overrides>
-        <trust-anchors>
             <certificates src="user" />
         </trust-anchors>
-    </debug-overrides>
+    </base-config>
 </network-security-config>


### PR DESCRIPTION
Fixes #191.

Android already has plenty of safeguards around installing custom CAs. So, trusting user-installed CAs should not be a security issue.