### PR TITLE
Add the ability to share downloaded attachments.

### DIFF
--- a/app/src/main/java/org/zotero/android/screens/itemdetails/ItemDetailsViewModel.kt
+++ b/app/src/main/java/org/zotero/android/screens/itemdetails/ItemDetailsViewModel.kt
@@ -1,8 +1,10 @@
 package org.zotero.android.screens.itemdetails
 
 import android.content.Context
+import android.content.Intent
 import android.net.Uri
 import android.webkit.MimeTypeMap
+import androidx.core.content.FileProvider.getUriForFile
 import androidx.core.net.toFile
 import androidx.core.net.toUri
 import androidx.lifecycle.SavedStateHandle
@@ -1427,6 +1429,9 @@ class ItemDetailsViewModel @Inject constructor(
                 is LongPressOptionItem.MoveToTrashAttachment -> {
                     delete(longPressOptionItem.attachment)
                 }
+                is LongPressOptionItem.ShareAttachmentFile -> {
+                    shareFile(longPressOptionItem.attachment)
+                }
                 is LongPressOptionItem.DeleteAttachmentFile -> {
                     deleteFile(longPressOptionItem.attachment)
                 }
@@ -1474,6 +1479,7 @@ class ItemDetailsViewModel @Inject constructor(
         val actions = mutableListOf<LongPressOptionItem>()
         val attachmentType = attachment.type
         if (attachmentType is Attachment.Kind.file && attachmentType.location == Attachment.FileLocation.local) {
+            actions.add(LongPressOptionItem.ShareAttachmentFile(attachment))
             actions.add(LongPressOptionItem.DeleteAttachmentFile(attachment))
         }
 
@@ -1557,6 +1563,38 @@ class ItemDetailsViewModel @Inject constructor(
 
         updateState {
             copy(data = data.deepCopy(creatorIds = updatedCreatorIds, creators = updatedCreators))
+        }
+    }
+
+    private fun shareFile(attachment: Attachment) {
+        when(val attachmentType = attachment.type) {
+            is Attachment.Kind.url -> {
+                attachmentType.url
+                val shareIntent: Intent = Intent().apply {
+                    action = Intent.ACTION_SEND
+                    putExtra(Intent.EXTRA_TEXT, attachmentType.url)
+                    type = "text/plain"
+                }
+                val chooserIntent = Intent.createChooser(shareIntent, null)
+                chooserIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                context.startActivity(chooserIntent)
+            }
+            is Attachment.Kind.file -> {
+                val file = fileStore.attachmentFile(
+                    libraryId = attachment.libraryId,
+                    key = attachment.key,
+                    filename = attachmentType.filename,
+                )
+                val uri = getUriForFile(context, context.packageName + ".provider", file)
+                val shareIntent: Intent = Intent().apply {
+                    action = Intent.ACTION_SEND
+                    putExtra(Intent.EXTRA_STREAM, uri)
+                    type = attachmentType.contentType
+                }
+                val chooserIntent = Intent.createChooser(shareIntent, null)
+                chooserIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                context.startActivity(chooserIntent)
+            }
         }
     }
 

--- a/app/src/main/java/org/zotero/android/uicomponents/bottomsheet/LongPressOptionItem.kt
+++ b/app/src/main/java/org/zotero/android/uicomponents/bottomsheet/LongPressOptionItem.kt
@@ -38,7 +38,7 @@ sealed class LongPressOptionItem(
 
     data class ShareAttachmentFile(val attachment: Attachment): LongPressOptionItem(
         titleId = Strings.item_detail_share_attachment_file,
-        resIcon = Drawables.delete_24px
+        resIcon = Drawables.baseline_share_24
     )
 
     data class DeleteAttachmentFile(val attachment: Attachment): LongPressOptionItem(

--- a/app/src/main/java/org/zotero/android/uicomponents/bottomsheet/LongPressOptionItem.kt
+++ b/app/src/main/java/org/zotero/android/uicomponents/bottomsheet/LongPressOptionItem.kt
@@ -36,6 +36,11 @@ sealed class LongPressOptionItem(
         resIcon = Drawables.delete_24px
     )
 
+    data class ShareAttachmentFile(val attachment: Attachment): LongPressOptionItem(
+        titleId = Strings.item_detail_share_attachment_file,
+        resIcon = Drawables.delete_24px
+    )
+
     data class DeleteAttachmentFile(val attachment: Attachment): LongPressOptionItem(
         titleId = Strings.item_detail_delete_attachment_file,
         resIcon = Drawables.delete_24px

--- a/app/src/main/res/drawable/baseline_share_24.xml
+++ b/app/src/main/res/drawable/baseline_share_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M18,16.08c-0.76,0 -1.44,0.3 -1.96,0.77L8.91,12.7c0.05,-0.23 0.09,-0.46 0.09,-0.7s-0.04,-0.47 -0.09,-0.7l7.05,-4.11c0.54,0.5 1.25,0.81 2.04,0.81 1.66,0 3,-1.34 3,-3s-1.34,-3 -3,-3 -3,1.34 -3,3c0,0.24 0.04,0.47 0.09,0.7L8.04,9.81C7.5,9.31 6.79,9 6,9c-1.66,0 -3,1.34 -3,3s1.34,3 3,3c0.79,0 1.5,-0.31 2.04,-0.81l7.12,4.16c-0.05,0.21 -0.08,0.43 -0.08,0.65 0,1.61 1.31,2.92 2.92,2.92 1.61,0 2.92,-1.31 2.92,-2.92s-1.31,-2.92 -2.92,-2.92z"/>
+    
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,5 +36,6 @@
 
     <string name="collection_remove_downloads">Remove Downloads</string>
     <string name="collection_empty_trash">Empty Trash</string>
+    <string name="item_detail.share_attachment_file">Share Download</string>
 
 </resources>


### PR DESCRIPTION
Looking at:

- https://forums.zotero.org/discussion/117783/zotero-android-download-files-into-shared-directory
- https://forums.zotero.org/discussion/118748/android-where-exactly-are-files-stored

This PR adds the ability to share downloaded attachment files (and technically text URLs, though this is unused) with other apps. Currently, one must long-press the attachment in the Item Details view, but more "findable" options can be implemented as desired.