### PR TITLE
FEAT: add settings entry to enable show subcollection items 

### DIFF
--- a/app/src/main/java/org/zotero/android/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/zotero/android/screens/settings/SettingsScreen.kt
@@ -16,9 +16,11 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import org.zotero.android.screens.dashboard.BuildInfo
 import org.zotero.android.screens.settings.elements.NewSettingsDivider
 import org.zotero.android.screens.settings.elements.NewSettingsItem
+import org.zotero.android.screens.settings.quickcopy.SettingsQuickCopySwitchItem
 import org.zotero.android.uicomponents.CustomScaffoldM3
 import org.zotero.android.uicomponents.Strings
 import org.zotero.android.uicomponents.themem3.AppThemeM3
+
 
 @Composable
 internal fun SettingsScreen(
@@ -32,6 +34,7 @@ internal fun SettingsScreen(
 ) {
     AppThemeM3 {
         val viewEffect by viewModel.viewEffects.observeAsState()
+        val viewState by viewModel.viewStates.observeAsState(SettingsViewState())
         LaunchedEffect(key1 = viewModel) {
             viewModel.init()
         }
@@ -93,6 +96,14 @@ internal fun SettingsScreen(
 
                 NewSettingsDivider()
 
+
+                SettingsQuickCopySwitchItem(
+                    title = stringResource(id = Strings.settings_show_subcollection_items),
+                    isChecked = viewState.showSubcollectionItems,
+                    onCheckedChange = viewModel::onShowSubcollectionItemsChanged
+                )
+
+                NewSettingsDivider()
                 BuildInfo()
             }
         }

--- a/app/src/main/java/org/zotero/android/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/org/zotero/android/screens/settings/SettingsViewModel.kt
@@ -4,15 +4,20 @@ import android.net.Uri
 import androidx.core.net.toUri
 import dagger.hilt.android.lifecycle.HiltViewModel
 import org.zotero.android.architecture.BaseViewModel2
+import org.zotero.android.architecture.Defaults
 import org.zotero.android.architecture.ViewEffect
 import org.zotero.android.architecture.ViewState
 import javax.inject.Inject
 
 @HiltViewModel
 internal class SettingsViewModel @Inject constructor(
+    private val defaults: Defaults
 ) : BaseViewModel2<SettingsViewState, SettingsViewEffect>(SettingsViewState()) {
 
-    fun init() = initOnce {
+    fun init(){
+        updateState {
+            copy(showSubcollectionItems = defaults.showSubcollectionItems())
+        }
     }
 
     fun onDone() {
@@ -28,10 +33,18 @@ internal class SettingsViewModel @Inject constructor(
         val uri = "https://forums.zotero.org/".toUri()
         triggerEffect(SettingsViewEffect.OpenWebpage(uri))
     }
+
+    fun onShowSubcollectionItemsChanged(newValue: Boolean) {
+        defaults.setShowSubcollectionItems(newValue)
+        updateState {
+            copy(showSubcollectionItems = newValue)
+        }
+    }
 }
 
 internal data class SettingsViewState(
     val placeholder: String = "",
+    val showSubcollectionItems: Boolean = true
 ) : ViewState
 
 internal sealed class SettingsViewEffect : ViewEffect {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,6 +51,7 @@
     <string name="pdf_reader_share_export_pdf">Export PDF</string>
     <string name="pdf_reader_share_export_annotated_pdf">Export Annotated PDF</string>
     <string name="settings_cite_remove_style">Remove Style</string>
+    <string name="settings_show_subcollection_items">Show Subcollection Items</string>
 
     <string name="items_generating_annotated_pdf">Generating Annotated PDF</string>
 


### PR DESCRIPTION
## Summary
Added switch element in SettingsScreen to change the "show subcollection items" value in the Shared Preferences. This allows users to see items from subcollections when clicking on parent.

## Changes
- Added showSubcollectionItems and onShowSubcollectionItemsChanged in SettingsViewState
- Added SettingsQuickCopySwitchItem in SettingsScreen

I notice the setting was already available in Defaults and used in the database requsets, but it was set to false. 
This should solve this [issue](https://github.com/zotero/zotero-android/issues/179)

