### PR TITLE
Improve bar hiding behavior in HTML/EPUB

### DIFF
--- a/app/src/main/java/org/zotero/android/screens/allitems/AllItemsViewModel.kt
+++ b/app/src/main/java/org/zotero/android/screens/allitems/AllItemsViewModel.kt
@@ -258,7 +258,8 @@ internal class AllItemsViewModel @Inject constructor(
                                 file = file,
                                 key = attachment.key,
                                 parentKey = parentKey,
-                                library = library
+                                library = library,
+                                contentType = contentType,
                             )
                         }
 
@@ -1276,13 +1277,14 @@ internal class AllItemsViewModel @Inject constructor(
         triggerEffect(AllItemsViewEffect.ShowCitationBibliographyExportEffect)
     }
 
-    private fun showHtmlEpub(file: File, key: String, parentKey: String?, library: Library) {
+    private fun showHtmlEpub(file: File, key: String, parentKey: String?, library: Library, contentType: String) {
         val uri = Uri.fromFile(file)
         val htmlEpubReaderArgs = HtmlEpubReaderArgs(
             key = key,
             parentKey = parentKey,
             library = library,
             uri = uri,
+            contentType = contentType,
         )
         val params = navigationParamsMarshaller.encodeObjectToBase64(htmlEpubReaderArgs)
         triggerEffect(AllItemsViewEffect.NavigateToHtmlEpubReaderScreen(params))

--- a/app/src/main/java/org/zotero/android/screens/htmlepub/reader/HtmlEpubReaderBox.kt
+++ b/app/src/main/java/org/zotero/android/screens/htmlepub/reader/HtmlEpubReaderBox.kt
@@ -1,23 +1,36 @@
 package org.zotero.android.screens.htmlepub.reader
 
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.rememberSplineBasedDecay
 import androidx.compose.foundation.gestures.AnchoredDraggableState
 import androidx.compose.foundation.gestures.DraggableAnchors
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsIgnoringVisibility
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBarDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import org.zotero.android.screens.htmlepub.reader.data.HtmlEpubReaderDocumentType
 import org.zotero.android.screens.htmlepub.reader.web.actionmenu.HtmlEpubActionMenuPopup
 import org.zotero.android.screens.htmlepub.toolbar.HtmlEpubReaderAnnotationCreationToolbar
 
@@ -58,39 +71,84 @@ internal fun HtmlEpubReaderBox(
     }
     val rightTargetAreaXOffset = with(density) { 92.dp.toPx() }
 
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .windowInsetsPadding(NavigationBarDefaults.windowInsets)
-            .onSizeChanged { layoutSize ->
-                val dragEndPoint = layoutSize.width - rightTargetAreaXOffset
-                anchoredDraggableState.updateAnchors(
-                    DraggableAnchors {
-                        DragAnchors.entries
-                            .forEach { anchor ->
-                                anchor at dragEndPoint * anchor.fraction
-                            }
-                    }
-                )
-            }
-    ) {
+    Box(modifier = Modifier.fillMaxSize()) {
         val selectedTextParamsRects = viewState.selectedTextParamsRects
         if (selectedTextParamsRects != null) {
             HtmlEpubActionMenuPopup(
                 selectedTextParamsRects = selectedTextParamsRects,
+                topInset = viewState.containerInsetTop,
+                leftInset = viewState.containerInsetLeft,
                 viewModel = viewModel,
             )
         }
 
-        HtmlEpubReaderWebView(viewModel)
+        val snapshotTopBarPadding by animateDpAsState(
+            targetValue = if (viewState.isTopBarVisible) {
+                TopAppBarDefaults.TopAppBarExpandedHeight
+            } else {
+                0.dp
+            },
+            label = "snapshotTopBarPadding",
+        )
+        val webViewModifier = if (viewState.type == HtmlEpubReaderDocumentType.EPUB) {
+            Modifier.fillMaxSize()
+        } else {
+            Modifier
+                .fillMaxSize()
+                .windowInsetsPadding(WindowInsets.systemBars)
+                .padding(top = snapshotTopBarPadding)
+        }
+        Box(modifier = webViewModifier) {
+            HtmlEpubReaderWebView(viewModel)
+        }
         if (viewState.showCreationToolbar) {
-            HtmlEpubReaderAnnotationCreationToolbar(
-                viewState = viewState,
-                viewModel = viewModel,
-                state = anchoredDraggableState,
-                onShowSnapTargetAreas = { shouldShowSnapTargetAreas = true },
-                shouldShowSnapTargetAreas = shouldShowSnapTargetAreas
-            )
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .windowInsetsPadding(NavigationBarDefaults.windowInsets)
+                    .onSizeChanged { layoutSize ->
+                        val dragEndPoint = layoutSize.width - rightTargetAreaXOffset
+                        anchoredDraggableState.updateAnchors(
+                            DraggableAnchors {
+                                DragAnchors.entries
+                                    .forEach { anchor ->
+                                        anchor at dragEndPoint * anchor.fraction
+                                    }
+                            }
+                        )
+                    }
+            ) {
+                HtmlEpubReaderAnnotationCreationToolbar(
+                    viewState = viewState,
+                    viewModel = viewModel,
+                    state = anchoredDraggableState,
+                    onShowSnapTargetAreas = { shouldShowSnapTargetAreas = true },
+                    shouldShowSnapTargetAreas = shouldShowSnapTargetAreas
+                )
+            }
+        }
+
+        // EPUB: When bars are hidden, show page progress in the empty space
+        val pageProgress = viewState.pageProgress
+        if (viewState.type == HtmlEpubReaderDocumentType.EPUB
+            && !viewState.isTopBarVisible
+            && pageProgress != null
+        ) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .fillMaxWidth()
+                    .windowInsetsPadding(WindowInsets.statusBarsIgnoringVisibility)
+                    .height(TopAppBarDefaults.TopAppBarExpandedHeight),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = pageProgress,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    style = MaterialTheme.typography.bodySmall,
+                    textAlign = TextAlign.Center,
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/org/zotero/android/screens/htmlepub/reader/HtmlEpubReaderScreen.kt
+++ b/app/src/main/java/org/zotero/android/screens/htmlepub/reader/HtmlEpubReaderScreen.kt
@@ -4,14 +4,19 @@ import android.view.MotionEvent
 import androidx.activity.compose.LocalActivity
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.systemBarsIgnoringVisibility
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInteropFilter
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
@@ -20,6 +25,7 @@ import androidx.lifecycle.Lifecycle
 import org.zotero.android.architecture.ui.CustomLayoutSize
 import org.zotero.android.architecture.ui.ObserveLifecycleEvent
 import org.zotero.android.screens.htmlepub.annotation.sidebar.HtmlEpubAnnotationNavigationView
+import org.zotero.android.screens.htmlepub.reader.data.HtmlEpubReaderDocumentType
 import org.zotero.android.screens.htmlepub.annotationmore.sidebar.HtmlEpubAnnotationMoreNavigationView
 import org.zotero.android.screens.htmlepub.reader.search.HtmlEpubReaderSearchViewModel
 import org.zotero.android.screens.htmlepub.reader.search.HtmlEpubReaderSearchViewState
@@ -28,6 +34,7 @@ import org.zotero.android.screens.htmlepub.reader.topbar.HtmlEpubReaderTopBar
 import org.zotero.android.screens.htmlepub.settings.sidebar.HtmlEpubSettingsView
 import org.zotero.android.uicomponents.CustomScaffoldM3
 import org.zotero.android.uicomponents.themem3.AppThemeM3
+import kotlin.math.roundToInt
 
 @Composable
 internal fun HtmlEpubReaderScreen(
@@ -62,10 +69,48 @@ internal fun HtmlEpubReaderScreen(
         val decorView = window.decorView
         val systemBars = WindowInsetsCompat.Type.systemBars()
         val insetsController = WindowCompat.getInsetsController(window, decorView)
-        if (viewState.isTopBarVisible) {
-            insetsController.show(systemBars)
-        } else {
+        val isEpub = viewState.type == HtmlEpubReaderDocumentType.EPUB
+        val isTopBarVisible = viewState.isTopBarVisible
+        // EPUB is immersive: hide the system bars together with the top bar
+        // HTML stays non-immersive so the system navigation bar remains
+        if (isEpub && !isTopBarVisible) {
             insetsController.hide(systemBars)
+        } else {
+            insetsController.show(systemBars)
+        }
+
+        // EPUB: Reserve space for the full-height system bars and app bar inside the reader
+        // HTML: Reserve space for the system bars outside the reader
+        val density = LocalDensity.current
+        val layoutDirection = LocalLayoutDirection.current
+        val systemBarsInsets = WindowInsets.systemBarsIgnoringVisibility
+        val topAppBarHeight = TopAppBarDefaults.TopAppBarExpandedHeight
+        val statusBarTop = with(density) { systemBarsInsets.getTop(this).toDp() }
+        val insetTop = (statusBarTop + topAppBarHeight).value.roundToInt()
+        val statusOnlyTop = statusBarTop.value.roundToInt()
+        val insetBottom = with(density) { systemBarsInsets.getBottom(this).toDp().value.roundToInt() }
+        val insetLeft =
+            with(density) { systemBarsInsets.getLeft(this, layoutDirection).toDp().value.roundToInt() }
+        val insetRight =
+            with(density) { systemBarsInsets.getRight(this, layoutDirection).toDp().value.roundToInt() }
+        LaunchedEffect(insetTop, statusOnlyTop, insetRight, insetBottom, insetLeft, isEpub, isTopBarVisible) {
+            if (isEpub) {
+                viewModel.onReaderInsetsChanged(
+                    top = insetTop,
+                    right = insetRight,
+                    bottom = insetBottom,
+                    left = insetLeft,
+                    reserveInsideReader = true,
+                )
+            } else {
+                viewModel.onReaderInsetsChanged(
+                    top = if (isTopBarVisible) insetTop else statusOnlyTop,
+                    right = insetRight,
+                    bottom = insetBottom,
+                    left = insetLeft,
+                    reserveInsideReader = false,
+                )
+            }
         }
 
         val focusManager = LocalFocusManager.current

--- a/app/src/main/java/org/zotero/android/screens/htmlepub/reader/HtmlEpubReaderViewModel.kt
+++ b/app/src/main/java/org/zotero/android/screens/htmlepub/reader/HtmlEpubReaderViewModel.kt
@@ -64,6 +64,7 @@ import org.zotero.android.helpers.FileHelper
 import org.zotero.android.helpers.formatter.iso8601DateFormatV3
 import org.zotero.android.helpers.formatter.iso8601WithFractionalSeconds
 import org.zotero.android.ktx.rounded
+import kotlin.math.roundToInt
 import org.zotero.android.pdf.data.PdfReaderCurrentThemeEventStream
 import org.zotero.android.pdf.data.PdfReaderThemeDecider
 import org.zotero.android.screens.htmlepub.ARG_HTML_EPUB_READER_SCREEN
@@ -81,6 +82,7 @@ import org.zotero.android.screens.htmlepub.htmlEpubFilter.data.HtmlEpubFilterArg
 import org.zotero.android.screens.htmlepub.htmlEpubFilter.data.HtmlEpubFilterResult
 import org.zotero.android.screens.htmlepub.reader.data.AnnotationTool
 import org.zotero.android.screens.htmlepub.reader.data.DocumentData
+import org.zotero.android.screens.htmlepub.reader.data.HtmlEpubReaderDocumentType
 import org.zotero.android.screens.htmlepub.reader.data.DocumentUpdate
 import org.zotero.android.screens.htmlepub.reader.data.HtmlEpubAnnotation
 import org.zotero.android.screens.htmlepub.reader.data.HtmlEpubAnnotationsFilter
@@ -170,6 +172,9 @@ class HtmlEpubReaderViewModel @Inject constructor(
     private var savedSearchTerm = ""
 
     private var selectedTextParamsText: String = ""
+
+    private var containerInsets = ContainerInsets()
+    private var isDocumentLoaded = false
 
     val screenArgs: HtmlEpubReaderArgs by lazy {
         val argsEncoded = stateHandle.get<String>(ARG_HTML_EPUB_READER_SCREEN).require()
@@ -329,11 +334,13 @@ class HtmlEpubReaderViewModel @Inject constructor(
 
     private fun initState() {
         val params = this.screenArgs
+        val type = HtmlEpubReaderDocumentType.fromContentType(params.contentType)
         updateState {
             copy(
                 key = params.key,
                 parentKey = params.parentKey,
                 library = params.library,
+                type = type,
             )
         }
     }
@@ -370,6 +377,48 @@ class HtmlEpubReaderViewModel @Inject constructor(
     private fun setTopBarVisibility(isVisible: Boolean) {
         updateState {
             copy(isTopBarVisible = isVisible)
+        }
+    }
+
+    /**
+     * Tells the reader how much space its content is offset by within the window.
+     * Values are in CSS pixels (== dp).
+     */
+    fun onReaderInsetsChanged(
+        top: Int,
+        right: Int,
+        bottom: Int,
+        left: Int,
+        reserveInsideReader: Boolean,
+    ) {
+        if (viewState.containerInsetTop != top || viewState.containerInsetLeft != left) {
+            updateState {
+                copy(containerInsetTop = top, containerInsetLeft = left)
+            }
+        }
+        if (!reserveInsideReader) {
+            return
+        }
+        val newInsets = ContainerInsets(top = top, right = right, bottom = bottom, left = left)
+        if (newInsets == containerInsets) {
+            return
+        }
+        containerInsets = newInsets
+        sendContainerInsets()
+    }
+
+    private fun sendContainerInsets() {
+        if (!isDocumentLoaded) {
+            return
+        }
+        val insets = containerInsets
+        viewModelScope.launch {
+            htmlEpubReaderWebCallChainExecutor?.setContainerInsets(
+                top = insets.top,
+                right = insets.right,
+                bottom = insets.bottom,
+                left = insets.left,
+            )
         }
     }
 
@@ -942,7 +991,7 @@ class HtmlEpubReaderViewModel @Inject constructor(
 
     fun loadItemAnnotationsAndPage(): Triple<RItem, RealmResults<RItem>, String>? {
         try {
-            val defaultPageValue = defaultPageValue(this.documentFile.extension.lowercase())
+            val defaultPageValue = defaultPageValue(viewState.type)
             val itemRequest =
                 ReadItemDbRequest(libraryId = viewState.library.identifier, key = viewState.key)
             val item = dbWrapperMain.realmDbStorage.perform(request = itemRequest)
@@ -965,36 +1014,24 @@ class HtmlEpubReaderViewModel @Inject constructor(
     }
 
 
-    private fun defaultPageValue(ext: String): String {
-        when(ext) {
-            "epub" -> {
-                return "_start"
-            }
-            "html", "htm" -> {
-                return "0"
-            }
-            else -> {
-                return ""
-            }
+    private fun defaultPageValue(type: HtmlEpubReaderDocumentType): String {
+        return when (type) {
+            HtmlEpubReaderDocumentType.EPUB -> "_start"
+            HtmlEpubReaderDocumentType.SNAPSHOT -> "0"
         }
     }
 
-    fun loadTypeAndPage(file: File, rawPage: String): Pair<String, Page?> {
-        when (this.documentFile.extension.lowercase()) {
-            "epub" -> {
-                return "epub" to Page.epub(cfi = rawPage)
-            }
-            "html", "htm" -> {
+    fun loadTypeAndPage(type: HtmlEpubReaderDocumentType, rawPage: String): Pair<String, Page?> {
+        return when (type) {
+            HtmlEpubReaderDocumentType.EPUB -> "epub" to Page.epub(cfi = rawPage)
+            HtmlEpubReaderDocumentType.SNAPSHOT -> {
                 val scrollYPercent = rawPage.toDoubleOrNull()
                 if (scrollYPercent != null) {
-                    return "snapshot" to Page.html(scrollYPercent = scrollYPercent)
+                    "snapshot" to Page.html(scrollYPercent = scrollYPercent)
                 } else {
                     Timber.e("HtmlEpubReaderViewModel: incompatible lastIndexPage stored for ${viewState.key} - $rawPage")
-                    return "snapshot" to null
+                    "snapshot" to null
                 }
-            }
-            else -> {
-                throw Error.incompatibleDocument
             }
         }
     }
@@ -1245,6 +1282,7 @@ class HtmlEpubReaderViewModel @Inject constructor(
     }
 
     fun setupWebView(webView: WebView) {
+        isDocumentLoaded = false
         this.htmlEpubReaderWebCallChainExecutor = HtmlEpubReaderWebCallChainExecutor(
             context = context,
             dispatchers = dispatchers,
@@ -1302,6 +1340,9 @@ class HtmlEpubReaderViewModel @Inject constructor(
             is HtmlEpubReaderWebData.setViewState -> {
                 setViewState(successValue.params)
             }
+            is HtmlEpubReaderWebData.setViewStats -> {
+                setViewStats(successValue.params)
+            }
             is HtmlEpubReaderWebData.showUrl -> {
                 showUrl(successValue.url)
             }
@@ -1340,6 +1381,38 @@ class HtmlEpubReaderViewModel @Inject constructor(
 
     }
 
+    private fun setViewStats(params: JsonObject) {
+        val stats = params["stats"]?.takeIf { it.isJsonObject }?.asJsonObject
+        fun JsonObject.intOrNull(key: String): Int? =
+            this[key]?.takeIf { it.isJsonPrimitive }?.asInt
+        fun JsonObject.stringOrNull(key: String): String? =
+            this[key]?.takeIf { it.isJsonPrimitive }?.asString
+        fun JsonObject.boolOrNull(key: String): Boolean? =
+            this[key]?.takeIf { it.isJsonPrimitive }?.asBoolean
+
+        val pageIndex = stats?.intOrNull("pageIndex")
+        val pagesCount = stats?.intOrNull("pagesCount")
+        val pageLabel = stats?.stringOrNull("pageLabel")
+        val usePhysicalPageNumbers = stats?.boolOrNull("usePhysicalPageNumbers") ?: false
+
+        // Hide the indicator unless we have what we need to build it: a page
+        // (label, or 1-based index) and a percentage (index over total pages).
+        val pageProgress = if (pageIndex != null && pagesCount != null && pagesCount > 0) {
+            val page = if (!pageLabel.isNullOrBlank()) pageLabel else (pageIndex + 1).toString()
+            val prefix = context.getString(
+                if (usePhysicalPageNumbers) Strings.page else Strings.location
+            )
+            val percent = (pageIndex.toDouble() / pagesCount * 100).roundToInt()
+            "$prefix $page ($percent%)"
+        } else {
+            null
+        }
+
+        if (viewState.pageProgress != pageProgress) {
+            updateState { copy(pageProgress = pageProgress) }
+        }
+    }
+
     private fun setSelectedTextParams(params: JsonObject) {
         this.selectedTextParams = params
         val rects = params["rect"].asJsonArray
@@ -1358,7 +1431,7 @@ class HtmlEpubReaderViewModel @Inject constructor(
             }
 
             val (sortedKeys, annotations, json) = processAnnotations(items = annotationItems)
-            val (type, page) = loadTypeAndPage(this.documentFile, rawPage = rawPage)
+            val (type, page) = loadTypeAndPage(viewState.type, rawPage = rawPage)
             val documentData = DocumentData(
                 type = type,
                 file = this.documentFile,
@@ -1382,6 +1455,8 @@ class HtmlEpubReaderViewModel @Inject constructor(
 //            }
             viewModelScope.launch {
                 htmlEpubReaderWebCallChainExecutor?.loadDocument(documentData)
+                isDocumentLoaded = true
+                sendContainerInsets()
                 restoreWebViewState()
             }
         } catch (e: Exception) {
@@ -1953,6 +2028,10 @@ data class HtmlEpubReaderViewState(
     val sidebarEditingEnabled: Boolean = false,
     var outlineSearch: String = "",
     val isTopBarVisible: Boolean = true,
+    val type: HtmlEpubReaderDocumentType = HtmlEpubReaderDocumentType.SNAPSHOT,
+    val pageProgress: String? = null,
+    val containerInsetTop: Int = 0,
+    val containerInsetLeft: Int = 0,
     val showPdfSearch: Boolean = false,
     val showSideBar: Boolean = false,
     val showCreationToolbar: Boolean = false,
@@ -1978,6 +2057,13 @@ data class HtmlEpubReaderViewState(
         return isCollapsed
     }
 }
+
+data class ContainerInsets(
+    val top: Int = 0,
+    val right: Int = 0,
+    val bottom: Int = 0,
+    val left: Int = 0,
+)
 
 sealed class HtmlEpubReaderViewEffect : ViewEffect {
     object NavigateBack : HtmlEpubReaderViewEffect()

--- a/app/src/main/java/org/zotero/android/screens/htmlepub/reader/data/HtmlEpubReaderArgs.kt
+++ b/app/src/main/java/org/zotero/android/screens/htmlepub/reader/data/HtmlEpubReaderArgs.kt
@@ -8,4 +8,5 @@ data class HtmlEpubReaderArgs(
     val parentKey: String?,
     val library: Library,
     val uri: Uri,
+    val contentType: String,
 )

--- a/app/src/main/java/org/zotero/android/screens/htmlepub/reader/data/HtmlEpubReaderDocumentType.kt
+++ b/app/src/main/java/org/zotero/android/screens/htmlepub/reader/data/HtmlEpubReaderDocumentType.kt
@@ -1,0 +1,15 @@
+package org.zotero.android.screens.htmlepub.reader.data
+
+enum class HtmlEpubReaderDocumentType {
+    EPUB,
+    SNAPSHOT;
+
+    companion object {
+        fun fromContentType(contentType: String): HtmlEpubReaderDocumentType {
+            return when (contentType) {
+                "application/epub+zip" -> EPUB
+                else -> SNAPSHOT
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/zotero/android/screens/htmlepub/reader/data/HtmlEpubReaderWebData.kt
+++ b/app/src/main/java/org/zotero/android/screens/htmlepub/reader/data/HtmlEpubReaderWebData.kt
@@ -9,6 +9,7 @@ sealed interface HtmlEpubReaderWebData {
     object deselectSelectedAnnotation : HtmlEpubReaderWebData
     data class setSelectedTextParams(val params: JsonObject) : HtmlEpubReaderWebData
     data class setViewState(val params: JsonObject) : HtmlEpubReaderWebData
+    data class setViewStats(val params: JsonObject) : HtmlEpubReaderWebData
     data class showUrl(val url: String) : HtmlEpubReaderWebData
 
     data class parseOutline(val params: JsonObject) : HtmlEpubReaderWebData

--- a/app/src/main/java/org/zotero/android/screens/htmlepub/reader/web/HtmlEpubReaderWebCallChainExecutor.kt
+++ b/app/src/main/java/org/zotero/android/screens/htmlepub/reader/web/HtmlEpubReaderWebCallChainExecutor.kt
@@ -176,6 +176,14 @@ class HtmlEpubReaderWebCallChainExecutor(
                                 )
                             )
                         }
+                        "onChangeViewStats" -> {
+                            val params = data["params"].asJsonObject
+                            observable.emitAsync(
+                                Result.Success(
+                                    HtmlEpubReaderWebData.setViewStats(params)
+                                )
+                            )
+                        }
                         "onOpenLink" -> {
                             val params = data["params"].asJsonObject
                             val url = params["url"].asString
@@ -245,6 +253,16 @@ class HtmlEpubReaderWebCallChainExecutor(
     suspend fun selectSearchResult(index: Int) {
         return suspendCancellableCoroutine { cont ->
             htmlEpubReaderWebViewHandler.evaluateJavascript("javascript:window._view.find({ index: '${index}' });") {
+                cont.resume(Unit)
+            }
+        }
+    }
+
+    suspend fun setContainerInsets(top: Int, right: Int, bottom: Int, left: Int) {
+        return suspendCancellableCoroutine { cont ->
+            htmlEpubReaderWebViewHandler.evaluateJavascript(
+                "javascript:setContainerInsets({ top: $top, right: $right, bottom: $bottom, left: $left });"
+            ) {
                 cont.resume(Unit)
             }
         }

--- a/app/src/main/java/org/zotero/android/screens/htmlepub/reader/web/actionmenu/HtmlEpubActionMenuPopup.kt
+++ b/app/src/main/java/org/zotero/android/screens/htmlepub/reader/web/actionmenu/HtmlEpubActionMenuPopup.kt
@@ -9,6 +9,8 @@ import org.zotero.android.screens.htmlepub.reader.HtmlEpubReaderViewModel
 @Composable
 fun HtmlEpubActionMenuPopup(
     selectedTextParamsRects: JsonArray,
+    topInset: Int,
+    leftInset: Int,
     viewModel: HtmlEpubReaderViewModel,
 ) {
     val onDismiss: () -> Unit = {
@@ -21,7 +23,11 @@ fun HtmlEpubActionMenuPopup(
             dismissOnClickOutside = true
         ),
         onDismissRequest = onDismiss,
-        popupPositionProvider = htmlEpubActionMenuPopupPositionProvider(selectedTextParamsRects),
+        popupPositionProvider = htmlEpubActionMenuPopupPositionProvider(
+            selectedTextParamsRects = selectedTextParamsRects,
+            topInset = topInset,
+            leftInset = leftInset,
+        ),
     ) {
         HtmlEpubActionMenu(viewModel)
     }

--- a/app/src/main/java/org/zotero/android/screens/htmlepub/reader/web/actionmenu/HtmlEpubActionMenuPopupPositionProvider.kt
+++ b/app/src/main/java/org/zotero/android/screens/htmlepub/reader/web/actionmenu/HtmlEpubActionMenuPopupPositionProvider.kt
@@ -14,6 +14,8 @@ import com.pspdfkit.internal.utilities.dpToPx
 @Composable
 internal fun htmlEpubActionMenuPopupPositionProvider(
     selectedTextParamsRects: JsonArray,
+    topInset: Int,
+    leftInset: Int,
 ) = object : PopupPositionProvider {
     val localDensity = LocalDensity.current
     override fun calculatePosition(
@@ -29,8 +31,8 @@ internal fun htmlEpubActionMenuPopupPositionProvider(
         val textSelectionTopY = selectedTextParamsRects[1].asString.toDouble()
 
         val popupHalfWidth = popupContentSize.width / 6
-        val finalX = textSelectionMiddleX - popupHalfWidth
-        val finalY = textSelectionTopY + popupContentSize.height / 8
+        val finalX = textSelectionMiddleX - popupHalfWidth + leftInset
+        val finalY = textSelectionTopY + popupContentSize.height / 8 + topInset
 
         return IntOffset(
             x = finalX.dp.dpToPx(localDensity).toInt(),

--- a/app/src/main/java/org/zotero/android/screens/itemdetails/ItemDetailsViewModel.kt
+++ b/app/src/main/java/org/zotero/android/screens/itemdetails/ItemDetailsViewModel.kt
@@ -1678,7 +1678,8 @@ class ItemDetailsViewModel @Inject constructor(
                         showHtmlEpub(
                             file = file,
                             parentKey = parentKey,
-                            attachment = attachment
+                            attachment = attachment,
+                            contentType = contentType,
                         )
                     }
                     "text/plain" -> {
@@ -2093,13 +2094,14 @@ class ItemDetailsViewModel @Inject constructor(
             }
         }
     }
-    private fun showHtmlEpub(file: File, parentKey: String?, attachment: Attachment) {
+    private fun showHtmlEpub(file: File, parentKey: String?, attachment: Attachment, contentType: String) {
         val uri = Uri.fromFile(file)
         val htmlEpubReaderArgs = HtmlEpubReaderArgs(
             key = attachment.key,
             parentKey = parentKey,
             library = viewState.library!!,
             uri = uri,
+            contentType = contentType,
         )
         val params = navigationParamsMarshaller.encodeObjectToBase64(htmlEpubReaderArgs)
         triggerEffect(ItemDetailsViewEffect.NavigateToHtmlEpubReaderScreen(params))

--- a/app/src/main/res/values/imported_strings.xml
+++ b/app/src/main/res/values/imported_strings.xml
@@ -26,6 +26,7 @@
     <string name="unknown">Unknown</string>
     <string name="retry">Retry</string>
     <string name="page">Page</string>
+    <string name="location">Location</string>
     <string name="report">Report</string>
     <string name="total">Total</string>
     <string name="restore">Restore</string>


### PR DESCRIPTION
**Snapshot:**
- Push content down when top bar becomes visible
- Always show system status/navigation bars

**EPUB:**
- Reserve space for bars even when hidden
- Don't push content down
- When hidden, show progress (page number and percentage) instead

Also update reader submodule.

@Dima-Android, this is basically what I was thinking re bar hiding / space reservation / avoiding EPUB reflows. Let me know what you think!

Should fix zotero/reader#205