### PR TITLE
Fix expanding unrelated collections on tablets

### DIFF
--- a/app/src/main/java/org/zotero/android/screens/collections/controller/CollectionTreeController.kt
+++ b/app/src/main/java/org/zotero/android/screens/collections/controller/CollectionTreeController.kt
@@ -392,6 +392,7 @@ class CollectionTreeController @Inject constructor(dispatchers: Dispatchers){
             if (traverseResult.first) {
                 return traverseResult
             }
+            listOfParents.removeLast()
         }
         return false to emptyList()
     }


### PR DESCRIPTION
## Summary

On tablets, whenever the collection tree is updated — for example after a sync or another collection change — all collection folders are expanded in the UI. This loses the user’s collapsed state and leaves a large collection hierarchy fully opened.

During an update, the app traverses the tree to reveal the currently selected collection. When a traversal branch does not contain the selected collection, its IDs remain in the shared parent list. Those unrelated folders are then mistaken for parents of the selected collection and expanded as well.

Pop the current parent when recursive traversal backtracks, so the UI expands only the actual parent path of the selected collection and leaves unrelated folders collapsed.

## Testing

- `./gradlew testDevDebugUnitTest`
- `./gradlew installDevDebug` on a Samsung Galaxy Tab S9 Ultra (SM-X910), followed by manual verification that collection-tree updates no longer expand unrelated folders