### PR TITLE
Strip "http://" and "https://" from the WebDAV URL field

### DIFF
--- a/app/src/main/java/org/zotero/android/screens/settings/account/SettingsAccountViewModel.kt
+++ b/app/src/main/java/org/zotero/android/screens/settings/account/SettingsAccountViewModel.kt
@@ -179,22 +179,33 @@ internal class SettingsAccountViewModel @Inject constructor(
     }
 
     fun setUrl(url: String) {
-        if (viewState.url == url) {
-            return
+        var newUrl = url.trim()
+
+        val scheme = WebDavScheme.entries.firstOrNull {
+            newUrl.startsWith("${it.name}://", ignoreCase = true)
         }
-        var decodedUrl = url
-        if (url.contains("%")) {
-            decodedUrl = HtmlCompat.fromHtml(
-                url,
+        if (scheme != null) {
+            newUrl = newUrl.removeRange(0, scheme.name.length + "://".length)
+            setScheme(scheme)
+        }
+
+        if (newUrl.contains("%")) {
+            newUrl = HtmlCompat.fromHtml(
+                newUrl,
                 HtmlCompat.FROM_HTML_MODE_LEGACY
             ).toString()
         }
-        sessionStorage.url = decodedUrl
+
+        if (viewState.url == newUrl) {
+            return
+        }
+
+        sessionStorage.url = newUrl
         webDavController.resetVerification()
 
         updateState {
             copy(
-                url = url,
+                url = newUrl,
                 webDavVerificationResult = null,
                 markingForReupload = true
             )


### PR DESCRIPTION
A scheme typed or pasted into the field was previously kept as part of the stored URL, which then produced a request URL with "https" as the host. The scheme is now removed and the scheme picker updated to match. Also trims surrounding whitespace and keeps the displayed URL in sync with the stored one.

https://forums.zotero.org/discussion/133187/got-webdav-issue-in-android-tablet-and-phone

(I haven't tested this within the app.)