### PR TITLE
Fix cross-library sync version checks and phantom item placeholders

### DIFF
--- a/app/src/main/java/org/zotero/android/database/requests/DeleteMissingPlaceholderItemsDbRequest.kt
+++ b/app/src/main/java/org/zotero/android/database/requests/DeleteMissingPlaceholderItemsDbRequest.kt
@@ -1,0 +1,43 @@
+package org.zotero.android.database.requests
+
+import io.realm.Realm
+import io.realm.kotlin.where
+import org.zotero.android.database.DbResponseRequest
+import org.zotero.android.database.objects.ObjectSyncState
+import org.zotero.android.database.objects.RItem
+import org.zotero.android.sync.LibraryIdentifier
+import timber.log.Timber
+
+/**
+ * Deletes placeholder items for keys that the server has confirmed don't exist in the given
+ * library. Only items in the `dirty` sync state (placeholders created before any real data was
+ * stored for them) with no local changes and no children are deleted; anything else is left for
+ * the regular resync/conflict machinery. Returns the keys that were deleted.
+ */
+class DeleteMissingPlaceholderItemsDbRequest(
+    private val libraryId: LibraryIdentifier,
+    private val keys: List<String>,
+) : DbResponseRequest<List<String>> {
+
+    override val needsWrite: Boolean
+        get() = true
+
+    override fun process(database: Realm): List<String> {
+        val deletedKeys = mutableListOf<String>()
+        val objects = database
+            .where<RItem>()
+            .keys(this.keys, this.libraryId)
+            .syncState(ObjectSyncState.dirty)
+            .findAll()
+        for (objectS in objects) {
+            if (objectS.isInvalidated || objectS.isChanged || !objectS.children!!.isEmpty()) {
+                continue
+            }
+            Timber.w("DeleteMissingPlaceholderItemsDbRequest: deleting placeholder ${objectS.key} missing remotely in $libraryId")
+            deletedKeys.add(objectS.key)
+            objectS.willRemove(database)
+            objectS.deleteFromRealm()
+        }
+        return deletedKeys
+    }
+}

--- a/app/src/main/java/org/zotero/android/database/requests/SyncVersionsDbRequest.kt
+++ b/app/src/main/java/org/zotero/android/database/requests/SyncVersionsDbRequest.kt
@@ -10,6 +10,7 @@ import org.zotero.android.database.objects.RGroup
 import org.zotero.android.database.objects.RItem
 import org.zotero.android.database.objects.RSearch
 import org.zotero.android.database.objects.Syncable
+import org.zotero.android.sync.LibraryIdentifier
 import org.zotero.android.sync.SyncKind
 import org.zotero.android.sync.SyncObject
 import java.lang.Integer.min
@@ -19,6 +20,7 @@ private typealias ResultSyncVersionsString = List<String>
 
 class SyncVersionsDbRequest(
     private val versions: Map<String, Int>,
+    private val libraryId: LibraryIdentifier,
     private val syncObject: SyncObject,
     val syncType: SyncKind,
     val delayIntervals: List<Double>
@@ -35,17 +37,20 @@ class SyncVersionsDbRequest(
                 return check(
                     objects = database
                         .where<RCollection>()
+                        .library(this.libraryId)
                         .findAll()
                 )
             SyncObject.search ->
                 return check(
                     objects = database
                         .where<RSearch>()
+                        .library(this.libraryId)
                         .findAll()
                 )
             SyncObject.item -> {
                 val objects = database
                     .where<RItem>()
+                    .library(this.libraryId)
                     .isTrash(false)
                     .findAll()
                 return check(
@@ -55,6 +60,7 @@ class SyncVersionsDbRequest(
             SyncObject.trash -> {
                 val objects = database
                     .where<RItem>()
+                    .library(this.libraryId)
                     .isTrash(true)
                     .findAll()
                 return check(

--- a/app/src/main/java/org/zotero/android/sync/SyncBatchProcessor.kt
+++ b/app/src/main/java/org/zotero/android/sync/SyncBatchProcessor.kt
@@ -21,6 +21,7 @@ import org.zotero.android.api.network.CustomResult
 import org.zotero.android.api.network.safeApiCall
 import org.zotero.android.architecture.coroutines.Dispatchers
 import org.zotero.android.database.DbWrapperMain
+import org.zotero.android.database.requests.DeleteMissingPlaceholderItemsDbRequest
 import org.zotero.android.database.requests.StoreCollectionsDbRequest
 import org.zotero.android.database.requests.StoreItemsDbResponseRequest
 import org.zotero.android.database.requests.StoreSearchesDbRequest
@@ -236,8 +237,24 @@ class SyncBatchProcessor @AssistedInject constructor(
                     denyIncorrectCreator = true,
                 )
                 val response = dbWrapperMain.realmDbStorage.perform(request = request, invalidateRealm = true)
+
+                // Keys the server didn't return at all, as opposed to keys whose data failed to
+                // parse or store. Placeholders for them can't ever be resolved by this request,
+                // so they're deleted instead of being marked for resync.
+                val responseKeys = dataArray.mapNotNull {
+                    try {
+                        it.asJsonObject["key"]?.asString
+                    } catch (e: Exception) {
+                        null
+                    }
+                }
+                val missingKeys =
+                    failedKeys(expectedKeys = expectedKeys, parsedKeys = responseKeys)
+                val deletedKeys =
+                    deleteMissingPlaceholders(keys = missingKeys, libraryId = libraryId)
                 val failedKeys =
                     failedKeys(expectedKeys = expectedKeys, parsedKeys = items.map { it.key })
+                        .filter { !deletedKeys.contains(it) }
 
                 renameExistingFiles(changes = response.changedFilenames, libraryId = libraryId)
                 SyncBatchResponse(failedKeys, errors, response.conflicts)
@@ -251,6 +268,15 @@ class SyncBatchProcessor @AssistedInject constructor(
 
     private fun failedKeys(expectedKeys: List<String>, parsedKeys: List<String>): List<String> {
         return expectedKeys.filter { !parsedKeys.contains(it) }
+    }
+
+    private fun deleteMissingPlaceholders(keys: List<String>, libraryId: LibraryIdentifier): List<String> {
+        if (keys.isEmpty()) {
+            return emptyList()
+        }
+        return dbWrapperMain.realmDbStorage.perform(
+            request = DeleteMissingPlaceholderItemsDbRequest(libraryId = libraryId, keys = keys)
+        )
     }
 
     private fun renameExistingFiles(changes: List<StoreItemsResponse.FilenameChange>, libraryId: LibraryIdentifier) {

--- a/app/src/main/java/org/zotero/android/sync/syncactions/SyncVersionsSyncAction.kt
+++ b/app/src/main/java/org/zotero/android/sync/syncactions/SyncVersionsSyncAction.kt
@@ -168,6 +168,7 @@ class SyncVersionsSyncAction @AssistedInject constructor(
 
             val request = SyncVersionsDbRequest(
                 versions = response,
+                libraryId = libraryId,
                 syncObject = objectS,
                 syncType = syncType,
                 delayIntervals = delayIntervals

--- a/buildSrc/src/main/kotlin/BuildConfig.kt
+++ b/buildSrc/src/main/kotlin/BuildConfig.kt
@@ -4,7 +4,7 @@ object BuildConfig {
     const val compileSdkVersion = 37
     const val targetSdk = 36
 
-    const val versionCode = 267 // Must be updated on every build
+    const val versionCode = 268 // Must be updated on every build
     val version = Version(
         major = 1,
         minor = 0,


### PR DESCRIPTION
Fixes https://forums.zotero.org/discussion/133276/android-beta1-0-0-267-sync-error-message — 1.0.0-267 fired ~54 `GET /users/<id>/items?itemKey=<50 keys>` requests in a few seconds, all returning empty arrays — roughly 2,700 item keys that don't exist in the user's library, re-requested on every backoff expiration and re-fired all at once by every full sync and pull-to-refresh. The keys are all from the user's group libraries rather than the user library being requested.

## Cause

Two mechanisms, one primary:

1. **`SyncVersionsDbRequest` had no library filter** (unlike its iOS counterpart, which filters every query with `.library(with: libraryId)`). It scanned all `RItem`/`RCollection`/`RSearch` objects in the database, so any non-synced object in one library was added to every other library's download list. Those keys don't exist in the other libraries, so the batch requests returned nothing, and `MarkForResyncDbAction` then **created dirty placeholder items for them in the wrong library**. The placeholders were themselves non-synced, so every stuck key (from an interrupted batch download, a parse failure, an item trashed mid-sync, etc.) was progressively copied into every synced library, compounding over time.

2. **Unreturned keys were always marked for resync, with no way out.** A dirty placeholder whose key the server never returns (deleted remotely before the client's deletions checkpoint, sitting in the trash — the by-key request doesn't send `includeTrashed=1` — or cloned from another library per the above) was retried forever on the 0.5h/1h/4h/16h/64h schedule, and `ignoreIndividualDelays`/`full` syncs bypass the schedule entirely.

## Fix

Two commits:

- **Restrict sync version checks to the library being synced** — `SyncVersionsDbRequest` now takes the library id and constrains all four object queries, matching iOS. This stops the cross-library breeding.
- **Delete placeholder items for keys the server doesn't return** — `SyncBatchProcessor` now distinguishes keys missing from the response entirely from keys whose data failed to parse or store. For missing keys, local placeholders are deleted instead of marked for resync, but only when the object is in the `dirty` state (no real data was ever stored for it) with no local changes and no children; everything else keeps the existing resync behavior. Deletion happens only on a successful batch response, which is a consistent snapshot of the library version (the `Last-Modified-Version` check has already passed).

The second commit also drains phantoms accumulated by existing installs: each placeholder is deleted after its next empty fetch, so affected devices self-heal after one retry cycle per library.

## Not addressed here

- **`includeTrashed=1` on by-key object requests** (desktop sends it; iOS and Android don't). Without it, a real (non-placeholder) `outdated` item that was trashed remotely still can't resolve through the item pipeline. Fixing it changes how trashed items flow through sync on both mobile platforms, so it's left for a separate decision.
- **Per-object retry cap.** The above removes the known unbounded-retry sources, so the backoff schedule is left as is.
- iOS shares the no-`includeTrashed` and no-retry-cap behaviors but has the library filter, so it can accumulate trashed-item phantoms at a much smaller scale.
