### PR TITLE
Fix scrubber long-press drag from recording every intermediate page in navigation history,

### DIFF
--- a/app/src/main/java/org/zotero/android/screens/reader/ReaderBox.kt
+++ b/app/src/main/java/org/zotero/android/screens/reader/ReaderBox.kt
@@ -13,7 +13,9 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.NavigationBarDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -27,6 +29,7 @@ import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import org.zotero.android.screens.reader.data.ReaderFileType
+import org.zotero.android.screens.reader.scrubber.ReaderPageHistoryArrowButton
 import org.zotero.android.screens.reader.scrubber.ReaderPageIndicatorLabel
 import org.zotero.android.screens.reader.scrubber.ReaderPageScrubber
 import org.zotero.android.screens.reader.scrubber.ReaderScrubberViewModel
@@ -118,9 +121,26 @@ internal fun ReaderBox(
                     verticalArrangement = Arrangement.spacedBy(6.dp),
                 ) {
                     ReaderPageIndicatorLabel(viewModel = scrubberViewModel)
-                    ReaderScrubberOverlay(
-                        visible = isScrubberVisible,
-                        scrubberViewModel = scrubberViewModel,
+                    AnimatedVisibility(visible = isScrubberVisible) {
+                        ReaderPageScrubber(viewModel = scrubberViewModel)
+                    }
+                }
+                if (isScrubberVisible) {
+                    ReaderPageHistoryBackArrow(
+                        visible = viewState.canNavigateBack,
+                        onClick = { viewModel.navigatePageHistoryBack() },
+                        modifier = Modifier
+                            .align(Alignment.BottomStart)
+                            .windowInsetsPadding(NavigationBarDefaults.windowInsets)
+                            .padding(start = 16.dp, bottom = ScrubberBottomClearance),
+                    )
+                    ReaderPageHistoryForwardArrow(
+                        visible = viewState.canNavigateForward,
+                        onClick = { viewModel.navigatePageHistoryForward() },
+                        modifier = Modifier
+                            .align(Alignment.BottomEnd)
+                            .windowInsetsPadding(NavigationBarDefaults.windowInsets)
+                            .padding(end = 16.dp, bottom = ScrubberBottomClearance),
                     )
                 }
             }
@@ -150,13 +170,27 @@ internal fun ReaderBox(
     }
 }
 
+private val ScrubberBottomClearance = 80.dp
+
 @Composable
-private fun ReaderScrubberOverlay(
+private fun ReaderPageHistoryBackArrow(
     visible: Boolean,
-    scrubberViewModel: ReaderScrubberViewModel,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
-    AnimatedVisibility(visible = visible) {
-        ReaderPageScrubber(viewModel = scrubberViewModel)
+    AnimatedVisibility(visible = visible, modifier = modifier) {
+        ReaderPageHistoryArrowButton(isForward = false, onClick = onClick)
+    }
+}
+
+@Composable
+private fun ReaderPageHistoryForwardArrow(
+    visible: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AnimatedVisibility(visible = visible, modifier = modifier) {
+        ReaderPageHistoryArrowButton(isForward = true, onClick = onClick)
     }
 }
 

--- a/app/src/main/java/org/zotero/android/screens/reader/ReaderViewModel.kt
+++ b/app/src/main/java/org/zotero/android/screens/reader/ReaderViewModel.kt
@@ -101,6 +101,7 @@ import org.zotero.android.screens.reader.settings.data.ReaderSettingsArgs
 import org.zotero.android.screens.reader.settings.data.ReaderSettingsChangeResult
 import org.zotero.android.screens.reader.sidebar.data.ReaderRequestAnnotationImageRenderEventStream
 import org.zotero.android.screens.reader.sidebar.data.ReaderRequestThumbnailRenderEventStream
+import org.zotero.android.screens.reader.sidebar.data.ReaderHistoryTrackingEvent
 import org.zotero.android.screens.reader.sidebar.data.ReaderScrollReaderIfNeededEvent
 import org.zotero.android.screens.reader.sidebar.data.ReaderSliderOptions
 import org.zotero.android.screens.reader.sidebar.data.ReaderWrapperOutline
@@ -266,7 +267,18 @@ class ReaderViewModel @Inject constructor(
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onEvent(result: ReaderScrollReaderIfNeededEvent) {
         viewModelScope.launch {
-            scrollReaderIfNeeded(result.location, false) {}
+            scrollReaderIfNeeded(result.location, false, skipHistory = result.skipHistory) {}
+        }
+    }
+
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onEvent(result: ReaderHistoryTrackingEvent) {
+        viewModelScope.launch {
+            if (result.suspend) {
+                readerWebCallChainExecutor.suspendHistoryTracking()
+            } else {
+                readerWebCallChainExecutor.resumeHistoryTrackingAndPush()
+            }
         }
     }
 
@@ -1734,6 +1746,12 @@ class ReaderViewModel @Inject constructor(
         val pagesCount = stats?.intOrNull("pagesCount")
         val pageLabel = stats?.stringOrNull("pageLabel")
         val usePhysicalPageNumbers = stats?.boolOrNull("usePhysicalPageNumbers") ?: false
+        val canNavigateBack = stats?.boolOrNull("canNavigateBack") ?: false
+        val canNavigateForward = stats?.boolOrNull("canNavigateForward") ?: false
+
+        if (viewState.canNavigateBack != canNavigateBack || viewState.canNavigateForward != canNavigateForward) {
+            updateState { copy(canNavigateBack = canNavigateBack, canNavigateForward = canNavigateForward) }
+        }
 
         // Hide the indicator unless we have what we need to build it: a page
         // (label, or 1-based index) and a percentage (index over total pages).
@@ -2532,18 +2550,36 @@ class ReaderViewModel @Inject constructor(
         readerWebCallChainExecutor.deselectText()
     }
 
-    private suspend fun scrollReaderIfNeeded(location: Map<String, Any>, animated: Boolean, completion: () -> Unit) {
+    fun navigatePageHistoryBack() {
+        if (!viewState.canNavigateBack) {
+            return
+        }
+        viewModelScope.launch {
+            readerWebCallChainExecutor.navigateBack()
+        }
+    }
+
+    fun navigatePageHistoryForward() {
+        if (!viewState.canNavigateForward) {
+            return
+        }
+        viewModelScope.launch {
+            readerWebCallChainExecutor.navigateForward()
+        }
+    }
+
+    private suspend fun scrollReaderIfNeeded(
+        location: Map<String, Any>,
+        animated: Boolean,
+        skipHistory: Boolean = false,
+        completion: () -> Unit,
+    ) {
 //        val locationsPage = location["pageNumber"] ?: location["pageIndex"]
 //        if (isCurrentFilePdf() && viewState.currentPdfPageIndex.toString() == locationsPage as String) {
 //            completion()
 //            return
 //        }
-        if (!animated) {
-            readerWebCallChainExecutor.show(location = location)
-            completion()
-            return
-        }
-        readerWebCallChainExecutor.show(location = location)
+        readerWebCallChainExecutor.show(location = location, skipHistory = skipHistory)
         completion()
     }
 
@@ -2658,6 +2694,8 @@ data class ReaderViewState(
     val toolColors: Map<ReaderAnnotationTool, String> = emptyMap(),
     val focusDocumentLocationAnnotationKey: String? = null,
     val pageProgress: String? = null,
+    val canNavigateBack: Boolean = false,
+    val canNavigateForward: Boolean = false,
     val fileType: ReaderFileType = ReaderFileType.EPUB,
     val isReaderLoading: Boolean = true,
     val annotationsUpdatedCounter: Int = 0,

--- a/app/src/main/java/org/zotero/android/screens/reader/scrubber/ReaderPageScrubber.kt
+++ b/app/src/main/java/org/zotero/android/screens/reader/scrubber/ReaderPageScrubber.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -22,8 +23,10 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBarDefaults
 import androidx.compose.material3.Text
@@ -40,15 +43,19 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.platform.ViewConfiguration
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import org.zotero.android.R
+import org.zotero.android.uicomponents.foundation.safeClickable
 import org.zotero.android.uicomponents.theme.CustomTheme
 import kotlin.math.roundToInt
 
@@ -80,17 +87,45 @@ internal fun ReaderPageIndicatorLabel(
                     .padding(horizontal = 14.dp, vertical = 6.dp),
                 contentAlignment = Alignment.Center,
             ) {
-                val baseStyle = MaterialTheme.typography.bodySmall
                 Text(
                     text = "${selectedPage + 1} of $pageCount",
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    style = baseStyle.copy(
-                        fontSize = baseStyle.fontSize * 2,
-                        lineHeight = baseStyle.lineHeight * 2,
-                    ),
+                    style = MaterialTheme.typography.bodySmall,
                 )
             }
         }
+    }
+}
+
+private val PageHistoryArrowSize = 32.dp
+private val PageHistoryArrowIconSize = 18.dp
+
+@Composable
+internal fun ReaderPageHistoryArrowButton(
+    isForward: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .size(PageHistoryArrowSize)
+            .clip(CircleShape)
+            .background(MaterialTheme.colorScheme.surfaceContainer)
+            .safeClickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+                onClick = onClick,
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            painter = painterResource(id = R.drawable.arrow_back_24dp),
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier
+                .size(PageHistoryArrowIconSize)
+                .graphicsLayer(rotationZ = if (isForward) 180f else 0f),
+        )
     }
 }
 

--- a/app/src/main/java/org/zotero/android/screens/reader/scrubber/ReaderScrubberViewModel.kt
+++ b/app/src/main/java/org/zotero/android/screens/reader/scrubber/ReaderScrubberViewModel.kt
@@ -16,6 +16,7 @@ import org.zotero.android.architecture.BaseViewModel2
 import org.zotero.android.architecture.ViewEffect
 import org.zotero.android.architecture.ViewState
 import org.zotero.android.pdf.data.PdfReaderCurrentThemeEventStream
+import org.zotero.android.screens.reader.sidebar.data.ReaderHistoryTrackingEvent
 import org.zotero.android.screens.reader.sidebar.data.ReaderScrollReaderIfNeededEvent
 import org.zotero.android.screens.reader.sidebar.thumbnails.ReaderThumbnailPreviewManager
 import org.zotero.android.screens.reader.sidebar.thumbnails.cache.ReaderThumbnailPreviewCacheSnapshotEventStream
@@ -66,6 +67,7 @@ internal class ReaderScrubberViewModel @Inject constructor(
 
     fun onScrubStart() {
         updateState { copy(isScrubbing = true) }
+        EventBus.getDefault().post(ReaderHistoryTrackingEvent(suspend = true))
     }
 
     fun onScrubTo(page: Int) {
@@ -73,7 +75,12 @@ internal class ReaderScrubberViewModel @Inject constructor(
         if (viewState.selectedPage != page) {
             updateState { copy(selectedPage = page) }
             val location = mapOf("pageNumber" to (page + 1).toString())
-            EventBus.getDefault().post(ReaderScrollReaderIfNeededEvent(location))
+            EventBus.getDefault().post(
+                ReaderScrollReaderIfNeededEvent(
+                    location,
+                    skipHistory = viewState.isScrubbing
+                )
+            )
         }
         thumbnailPreviewManager.requestThumbnail(page)
         showPageLabelTemporarily()
@@ -81,6 +88,7 @@ internal class ReaderScrubberViewModel @Inject constructor(
 
     fun onScrubEnd() {
         updateState { copy(isScrubbing = false) }
+        EventBus.getDefault().post(ReaderHistoryTrackingEvent(suspend = false))
     }
 
     fun onTapAt(page: Int) {

--- a/app/src/main/java/org/zotero/android/screens/reader/sidebar/data/ReaderHistoryTrackingEvent.kt
+++ b/app/src/main/java/org/zotero/android/screens/reader/sidebar/data/ReaderHistoryTrackingEvent.kt
@@ -1,0 +1,3 @@
+package org.zotero.android.screens.reader.sidebar.data
+
+data class ReaderHistoryTrackingEvent(val suspend: Boolean)

--- a/app/src/main/java/org/zotero/android/screens/reader/sidebar/data/ReaderScrollReaderIfNeededEvent.kt
+++ b/app/src/main/java/org/zotero/android/screens/reader/sidebar/data/ReaderScrollReaderIfNeededEvent.kt
@@ -1,3 +1,6 @@
 package org.zotero.android.screens.reader.sidebar.data
 
-data class ReaderScrollReaderIfNeededEvent(val location: Map<String, Any>)
+data class ReaderScrollReaderIfNeededEvent(
+    val location: Map<String, Any>,
+    val skipHistory: Boolean = false
+)

--- a/app/src/main/java/org/zotero/android/screens/reader/web/ReaderWebCallChainExecutor.kt
+++ b/app/src/main/java/org/zotero/android/screens/reader/web/ReaderWebCallChainExecutor.kt
@@ -176,7 +176,10 @@ class ReaderWebCallChainExecutor @Inject constructor(
                                     ?.takeIf { !it.isJsonNull }?.asBoolean ?: false
                                 observable.emitAsync(
                                     Result.Success(
-                                        ReaderWebData.selectAnnotationFromDocument(key, inlineTextEditing)
+                                        ReaderWebData.selectAnnotationFromDocument(
+                                            key,
+                                            inlineTextEditing
+                                        )
                                     )
                                 )
                             } else {
@@ -292,11 +295,43 @@ class ReaderWebCallChainExecutor @Inject constructor(
         }
     }
 
-    suspend fun show(location: Map<String, Any>) {
+    suspend fun show(location: Map<String, Any>, skipHistory: Boolean = false) {
         val encodedPayload = encodeAsJSONForJavascript(gson = gson, data = location)
 
         return suspendCancellableCoroutine { cont ->
-            readerWebViewHandler.evaluateJavascript("javascript:navigate({ location: '${encodedPayload}' });") {
+            readerWebViewHandler.evaluateJavascript("javascript:navigate({ location: '${encodedPayload}', skipHistory: $skipHistory });") {
+                cont.resume(Unit)
+            }
+        }
+    }
+
+    suspend fun navigateBack() {
+        return suspendCancellableCoroutine { cont ->
+            readerWebViewHandler.evaluateJavascript("javascript:navigateBack();") {
+                cont.resume(Unit)
+            }
+        }
+    }
+
+    suspend fun navigateForward() {
+        return suspendCancellableCoroutine { cont ->
+            readerWebViewHandler.evaluateJavascript("javascript:navigateForward();") {
+                cont.resume(Unit)
+            }
+        }
+    }
+
+    suspend fun suspendHistoryTracking() {
+        return suspendCancellableCoroutine { cont ->
+            readerWebViewHandler.evaluateJavascript("javascript:suspendHistoryTracking();") {
+                cont.resume(Unit)
+            }
+        }
+    }
+
+    suspend fun resumeHistoryTrackingAndPush() {
+        return suspendCancellableCoroutine { cont ->
+            readerWebViewHandler.evaluateJavascript("javascript:resumeHistoryTrackingAndPush();") {
                 cont.resume(Unit)
             }
         }
@@ -436,7 +471,8 @@ class ReaderWebCallChainExecutor @Inject constructor(
                 is ReaderPage.pdf -> {
                     createReaderViewOptions.viewState.pageIndex = page.pageIndex
                     createReaderViewOptions.viewState.spreadMode = spreadsModeInt
-                    createReaderViewOptions.viewState.scrollMode = defaults.getReaderSettings().scrollMode.jsValue
+                    createReaderViewOptions.viewState.scrollMode =
+                        defaults.getReaderSettings().scrollMode.jsValue
                 }
             }
         }

--- a/buildSrc/src/main/kotlin/BuildConfig.kt
+++ b/buildSrc/src/main/kotlin/BuildConfig.kt
@@ -4,7 +4,7 @@ object BuildConfig {
     const val compileSdkVersion = 37
     const val targetSdk = 36
 
-    const val versionCode = 280 // Must be updated on every build
+    const val versionCode = 281 // Must be updated on every build
     val version = Version(
         major = 1,
         minor = 0,


### PR DESCRIPTION
Reader PDF: Back/forward page-jump history navigation arrows for the scrubber
